### PR TITLE
Build: Exit on gradle failures to help protect against bad releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.10
  - Fix gradle now that Event has been moved into Logstash Core
+ - Exit on gradle failures to help protect against bad releases 
 
 ## 1.0.9
  - Docs: Fix doc generation error by removing illegal heading
@@ -7,7 +8,7 @@
 
 ## 1.0.8
  - Add "vendor/jars" to require_paths in gemspec
- 
+
 ## 1.0.7
  - Update the version and rebuild the vendored jar.
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,13 +9,13 @@ require 'rspec/core/rake_task'
 
 desc "Compile and vendor java into ruby"
 task :vendor => [:bundle_install] do
-  sh("./gradlew check vendor")
+  exit(1) unless system './gradlew check vendor'
   puts "-------------------> vendored dissect jar via rake"
 end
 
 desc "Compile and vendor java into ruby for travis, its done bundle install already"
 task :travis_vendor => [:write_gradle_properties] do
-  sh("./gradlew check vendor")
+  exit(1) unless system './gradlew check vendor'
   puts "-------------------> vendored dissect jar via rake"
 end
 
@@ -52,5 +52,3 @@ def delete_create_gradle_properties
   puts "-------------------> Wrote #{gradle_properties_file}"
   puts `cat #{gradle_properties_file}`
 end
-
-


### PR DESCRIPTION
Exit on gradle failures to help protect against bad releases