### PR TITLE
Update index.asciidoc

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -240,8 +240,8 @@ For example
 filter {
   dissect {
     convert_datatype => {
-      cpu => "float"
-      code => "int"
+      "cpu" => "float"
+      "code" => "int"
     }
   }
 }


### PR DESCRIPTION
In convert_datatype functionality, 'field names' are also supposed to be under double quotations to support spaced field names.
