### PR TITLE
Build: take the last line from output to fix failing CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,7 +73,7 @@ end
 def delete_create_gradle_properties
   root_dir = File.dirname(__FILE__)
   gradle_properties_file = "#{root_dir}/gradle.properties"
-  lsc_path = `bundle show logstash-core`.split(/\n/).first
+  lsc_path = `bundle show logstash-core`.split(/\n/).last
 
   FileUtils.rm_f(gradle_properties_file)
   File.open(gradle_properties_file, "w") do |f|


### PR DESCRIPTION

~~due potential err redirected -> out capturing warnings~~

with JRUBY_OPTS containing `-XX:+PrintCommandLineFlags` the first captured line will not contain the expected path to logstash-core on `bundle show logstash-core` but:
```
-------------------> Wrote /usr/share/plugins/plugin/gradle.properties
logstashCoreGemPath=-XX:InitialHeapSize=130380480 -XX:MaxHeapSize=2086087680 -XX:+PrintCommandLineFlags -XX:ReservedCodeCacheSize=251658240 -XX:+SegmentedCodeCache -XX:ThreadStackSize=2048 -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseParallelGC
```