### PR TITLE
Remove Maven local repository from gradle's build.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
 buildscript {
     repositories {
-        mavenLocal()
         mavenCentral()
     }
 }
@@ -13,7 +12,6 @@ plugins {
     id "me.champeau.jmh" version "0.6.6"
 }
 repositories {
-    mavenLocal()
     mavenCentral()
 }
 


### PR DESCRIPTION
As described in https://docs.gradle.org/7.4.2/userguide/declaring_repositories.html#sec:case-for-maven-local maven local is cache and is discouraged.


