### PR TITLE
Fix/rakefile to use same jruby env

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,7 +73,8 @@ end
 def delete_create_gradle_properties
   root_dir = File.dirname(__FILE__)
   gradle_properties_file = "#{root_dir}/gradle.properties"
-  lsc_path = `bundle show logstash-core`.split(/\n/).last
+  # find the path to the logstash-core gem
+  lsc_path = Bundler.rubygems.find_name("logstash-core").first.full_gem_path
 
   FileUtils.rm_f(gradle_properties_file)
   File.open(gradle_properties_file, "w") do |f|

--- a/Rakefile
+++ b/Rakefile
@@ -61,12 +61,14 @@ task :custom_ls_check, :ls_dir do |task, args|
 end
 
 def custom_ls_path_shell_script(path)
+  # Use same JRuby that launched this Rake
+  current_ruby_path = RbConfig::CONFIG['prefix']
   <<TXT
 export LOGSTASH_PATH='#{path}'
 export LOGSTASH_SOURCE=1
-bundle install
-bundle exec rake travis_vendor
-bundle exec rspec spec
+#{current_ruby_path}/bin/jruby -S bundle install
+#{current_ruby_path}/bin/jruby -S bundle exec rake travis_vendor
+#{current_ruby_path}/bin/jruby -S bundle exec rspec spec
 TXT
 end
 


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip]

## What does this PR do?

Avoid to fork a bundler process to extract `logstash-core`'s path and use the same bundler that wraps the execution of the Rakefile itself.

## Why is it important/What is the impact to the user?

All the Rake tasks must run with same JRuby distribution that launched the execution. Without this, it uses the system's Ruby.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run with system's JRuby
- [x] run with not the system's JRuby

## How to test this PR locally

Verify that it works with Logstash JRuby distribution:
```sh
export LOGSTASH_PATH=/tmp/logstash/ && export LOGSTASH_SOURCE=1
/tmp/logstash/bin/ruby -S bundle install
/tmp/logstash/bin/ruby -S exec rake vendor
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #89