### PR TITLE
Additional Dissector.java 

### DIFF
--- a/src/test/java/org/logstash/dissect/DissectorTest.java
+++ b/src/test/java/org/logstash/dissect/DissectorTest.java
@@ -482,4 +482,23 @@ public class DissectorTest {
         assertEquals("ZZZ", object.get("z"));
         assertTrue(result.matched());
     }
+
+    // First test to define correct behaviour for elasticsearch#119264
+    @Test
+    public void testForConcurrentDelimitersAdditional() throws Exception {
+        final Map<String, Object> object = new HashMap<>();
+        subject("%{a}-%{b}")
+                .dissect("foo------bar".getBytes(), object);
+        assertEquals("foo", object.get("a"));
+        assertEquals("-----bar", object.get("b"));
+    }
+
+    // Second test to define correct behaviour for elasticsearch#119264
+    @Test
+    public void testForConcurrentDelimitersAdditionalWithEmptyMatches() throws Exception {
+        final Map<String, Object> object = new HashMap<>();
+        subject("%{}|%{}|foo=%{field}")
+                .dissect("||foo=bar".getBytes(), object);
+        assertEquals("bar", object.get("field"));
+    }
 }


### PR DESCRIPTION
Tests for additional repeating delimiter edge cases that cover an edge case behaviour we are seeing in the Elasticsearch dissect ingest processor.

These tests pass in this plugin which helps us determine the "correct" behaviours for this case.